### PR TITLE
add set_project_milestone_nth_week

### DIFF
--- a/dags/serivces/__init__.py
+++ b/dags/serivces/__init__.py
@@ -1,2 +1,3 @@
 from .mentor import set_mentor_role_id, get_mentor_map_dict, get_mentor_info, insert_participant_into_mentor
 from .valid_contestants import get_valid_contestants, set_player_role_id, get_marthon_user_list
+from .milestone import fetch_project_milestones

--- a/dags/serivces/milestone.py
+++ b/dags/serivces/milestone.py
@@ -1,0 +1,19 @@
+from sqlalchemy import text, select
+
+def fetch_project_milestones(session, project_id: int):
+    """ 調用 get_project_milestone_dates(project_id) 取得里程碑數據 """
+    sql = text("SELECT * FROM public.get_project_milestone_dates(:project_id)")
+    result = session.execute(sql, {"project_id": project_id})
+
+    return [
+        {
+            "project_id": row[0],
+            "project_title": row[1],  # 假設 project_title 可用作 milestone name
+            "milestone_id": row[2],
+            "start_date": row[3],
+            "end_date": row[4],
+            "week": row[5],
+            "is_completed": row[6]
+        }
+        for row in result.fetchall()
+    ]

--- a/dags/set_project_milestone_nth_week.py
+++ b/dags/set_project_milestone_nth_week.py
@@ -1,0 +1,24 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from datetime import datetime
+from migrate_marathon import default_args, set_project_milestone_nth_week
+
+
+with DAG(
+    "set_project_milestone_nth_week",
+    tags=["migrate", "marathon", "project"],
+    default_args=default_args,
+    description="set all milestone nth week",
+    schedule_interval=None,
+    start_date=datetime(2023, 12, 9),
+    catchup=False,
+) as dag:
+    
+    # --- DAG 定義 ---
+    set_milestone_nth_week = PythonOperator(
+        task_id="set_project_milestone_nth_week",
+        python_callable=set_project_milestone_nth_week,
+        dag=dag
+    )
+
+    set_milestone_nth_week 

--- a/init-scripts/99-05-get_project_milestone_dates.sql
+++ b/init-scripts/99-05-get_project_milestone_dates.sql
@@ -2,6 +2,7 @@ CREATE OR REPLACE FUNCTION public.get_project_milestone_dates(p_project_id integ
 RETURNS TABLE(
     project_id integer, 
     project_title text, 
+    milestone_id integer,
     milestone_start_date date, 
     milestone_end_date date, 
     week_number integer,
@@ -14,6 +15,7 @@ BEGIN
     SELECT
         p.id AS project_id,  
         p.title::TEXT AS project_title,
+        m.id AS milestone_id,
         m.start_date AS milestone_start_date,
         m.end_date AS milestone_end_date,
         ((EXTRACT(DAY FROM (m.start_date::timestamp - (SELECT MIN(m2.start_date) FROM public.milestone m2 WHERE m2.project_id = p.id))) / 7) + 1)::integer AS week_number,


### PR DESCRIPTION
## Summary by Sourcery

Adds a new DAG to set the week number for project milestones and enhances the milestone data retrieval process.

New Features:
- Introduces a new Airflow DAG, `set_project_milestone_nth_week`, to automatically set the 'week' value for each project milestone in the database.

Enhancements:
- Improves milestone data retrieval by including the milestone ID in the `get_project_milestone_dates` function.
- Adds a new service function `fetch_project_milestones` to retrieve milestone data for a given project.