### PR TITLE
Feat/add nth week in milestone

### DIFF
--- a/init-scripts/02-05-create-project-tables.sql
+++ b/init-scripts/02-05-create-project-tables.sql
@@ -139,7 +139,7 @@ CREATE TABLE "review" (
     FOREIGN KEY ("post_id") REFERENCES "post"("id") ON DELETE CASCADE
 );
 
-CREATE INDEX idx_review_project_id ON "review"("project_id");
+CREATE INDEX idx_review_post_id ON "review"("post_id");
 
 -- 回覆評論表，存放針對文章的使用者評論
 CREATE TABLE "comments" (
@@ -158,8 +158,8 @@ CREATE INDEX idx_comments_visibility ON "comments"("visibility");
 
 CREATE TABLE "likes" (
     "id" SERIAL PRIMARY KEY,
-    "post_id" INT REFERENCES posts(id) ON DELETE CASCADE,
+    "post_id" INT REFERENCES post(id) ON DELETE CASCADE,
     "user_id" INT REFERENCES users(id) ON DELETE CASCADE,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX idx_likes_post_user ON "likes"("post_id", "user_id");

--- a/init-scripts/02-05-create-project-tables.sql
+++ b/init-scripts/02-05-create-project-tables.sql
@@ -74,6 +74,7 @@ CREATE TABLE "task" (
     FOREIGN KEY ("milestone_id") REFERENCES "milestone"("id") ON DELETE CASCADE
 );
 
+CREATE INDEX idx_task_milestone_id ON "task"("milestone_id");
 
 -- 通用文章表，包含學習成果、便利貼，統一以 project_id 表示所屬專案。
 CREATE TABLE "post" (

--- a/init-scripts/02-05-create-project-tables.sql
+++ b/init-scripts/02-05-create-project-tables.sql
@@ -74,17 +74,17 @@ CREATE TABLE "task" (
     FOREIGN KEY ("milestone_id") REFERENCES "milestone"("id") ON DELETE CASCADE
 );
 
+
 -- 通用文章表，包含學習成果、便利貼，統一以 project_id 表示所屬專案。
 CREATE TABLE "post" (
     "id" SERIAL PRIMARY KEY,
     "project_id" INT NOT NULL REFERENCES "project"("id") ON DELETE CASCADE,
     "user_id" INT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
-    "type" VARCHAR(20) NOT NULL CHECK ("type" IN ('outcome', 'note')),
+    "type" VARCHAR(20) NOT NULL CHECK ("type" IN ('outcome', 'note', 'review')),
     "week" INT NOT NULL,
     "title" VARCHAR(255) NOT NULL,
-    "content" TEXT NOT NULL,
     "date" DATE NOT NULL, 
-    "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public', 'mentor_participant', 'private')),
+    "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public', 'private')),
     "status" VARCHAR(20) DEFAULT 'draft' CHECK ("status" IN ('draft', 'published')),
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -96,6 +96,7 @@ CREATE INDEX idx_posts_project_status ON "post"("project_id", "status");
 CREATE TABLE "outcome" (
     "id" SERIAL PRIMARY KEY,
     "post_id" INT NOT NULL,
+    "content" TEXT NOT NULL,
     "image_urls" TEXT[],  -- 儲存圖片 URL
     "video_urls" TEXT[],  -- 儲存影片 URL
     "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public', 'private')),
@@ -110,6 +111,7 @@ CREATE INDEX idx_outcome_post_id ON "outcome"("post_id");
 CREATE TABLE "note" (
     "id" SERIAL PRIMARY KEY,
     "post_id" INT NOT NULL,
+    "content" TEXT NOT NULL,
     "image_urls" TEXT[],  -- 儲存圖片 URL
     "video_urls" TEXT[],  -- 儲存影片 URL
     "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public', 'private')),
@@ -123,12 +125,13 @@ CREATE INDEX idx_note_post_id ON "note"("post_id");
 -- 覆盤表，針對專案進行回顧與調整
 CREATE TABLE "review" (
     "id" SERIAL PRIMARY KEY,
-    "post_id" INT NOT NULL, -- adjust_plan
+    "post_id" INT NOT NULL, 
     "mood" VARCHAR(20) NOT NULL CHECK ("mood" IN ('happy', 'calm', 'anxious', 'tired', 'frustrated')),
     "mood_description" TEXT,
     "stress_level" SMALLINT NOT NULL CHECK ("stress_level" BETWEEN 1 AND 10),
     "learning_review" SMALLINT NOT NULL CHECK ("learning_review" BETWEEN 1 AND 10),
     "learning_feedback" TEXT,
+    "adjustment_plan" TEXT, -- 調整與規劃
     "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public', 'private')),
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -143,11 +146,19 @@ CREATE TABLE "comments" (
     "post_id" INT NOT NULL REFERENCES "post"("id") ON DELETE CASCADE,
     "user_id" INT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
     "content" TEXT NOT NULL,
-    "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public','mentor_participant','private')),
-    "mentor_id" INTEGER,
+    "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public','private')),
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX idx_comments_post_user ON "comments"("post_id", "user_id");
+CREATE INDEX idx_comments_visibility ON "comments"("visibility");
 
+
+CREATE TABLE "likes" (
+    "id" SERIAL PRIMARY KEY,
+    "post_id" INT REFERENCES posts(id) ON DELETE CASCADE,
+    "user_id" INT REFERENCES users(id) ON DELETE CASCADE,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+);
+CREATE INDEX idx_likes_post_user ON "likes"("post_id", "user_id");

--- a/init-scripts/02-05-create-project-tables.sql
+++ b/init-scripts/02-05-create-project-tables.sql
@@ -1,146 +1,153 @@
+-- 專案表，使用 UUID 作為外部識別碼，並針對必要欄位加上 NOT NULL 限制
 CREATE TABLE "project" (
     "id" SERIAL PRIMARY KEY,
-    "external_id" UUID DEFAULT gen_random_uuid() UNIQUE, -- 使用 UUID 作为唯一标识符并添加唯一约束
-    "user_id" int NOT NULL,
-    "img_url" varchar(255),
-    "title" varchar(255),
-    "description" text,
+    "external_id" UUID DEFAULT gen_random_uuid() UNIQUE, -- 使用 UUID 作為全局唯一標識符
+    "user_id" INT NOT NULL,
+    "img_url" VARCHAR(255),
+    "title" VARCHAR(255) NOT NULL,
+    "description" TEXT,
     "motivation" motivation_t[],
-    "motivation_description" text,
-    "goal" varchar(255),
-    "content" text,
+    "motivation_description" TEXT,
+    "goal" VARCHAR(255),
+    "content" TEXT,
     "strategy" strategy_t[],
-    "strategy_description" text,
-    -- "resource_name" text[],
-    -- "resource_url" text[],
-    "resource" TEXT,  -- 這邊之後要跟找資源的resource資料表串一起
+    "strategy_description" TEXT,
+    "resource" TEXT,  -- 未來可與資源資料表串接
     "outcome" outcome_t[],
-    "outcome_description" text,
-    "is_public" boolean DEFAULT false,  -- 是否公開
-    "status" varchar(50) DEFAULT 'Not Started' CHECK ("status" IN ('Ongoing', 'Completed', 'Not Started', 'Canceled')),
-    "start_date" date, -- 開始日期
-    "end_date" date CHECK ("start_date" < "end_date"), -- 結束日期
-    "interval" int CHECK ("interval" > 0), -- 週期間隔（單位：週，必須大於 0）
-    "created_at" timestamp DEFAULT current_timestamp,
-    "created_by" int,
-    "updated_at" timestamp DEFAULT current_timestamp,
-    "updated_by" int,
-    "version" int,
+    "outcome_description" TEXT,
+    "is_public" BOOLEAN DEFAULT false,  -- 是否公開
+    "status" VARCHAR(50) DEFAULT 'Not Started' CHECK ("status" IN ('Ongoing', 'Completed', 'Not Started', 'Canceled')),
+    "start_date" DATE,
+    "end_date" DATE CHECK ("start_date" < "end_date"),
+    "interval" INT CHECK ("interval" > 0),
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" INT,
+    "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "updated_by" INT,
+    "version" INT,
     FOREIGN KEY ("user_id") REFERENCES "users"("id"),
     UNIQUE ("user_id", "title", "version")
 );
 
+-- 使用者與專案關聯表，採用id作為使用者與專案的外部識別碼
 CREATE TABLE "user_project" (
     "id" SERIAL PRIMARY KEY,
-    "user_external_id" UUID, -- 改为 UUID
-    "project_id" int, -- 改为 UUID
-    FOREIGN KEY ("user_external_id") REFERENCES "users"("external_id") ON DELETE CASCADE,
-    FOREIGN KEY ("project_id") REFERENCES "project"("id") ON DELETE CASCADE
+    "user_id" INT NOT NULL,  -- 參照 users 表的 id
+    "project_id" INT NOT NULL,  -- 參照 project 表的 id
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE,
+    FOREIGN KEY ("project_id") REFERENCES "project"("id") ON DELETE CASCADE,
+    UNIQUE ("user_id", "project_id")
 );
 
-
--- 創建 milestone 表
+-- 里程碑表，規範必要欄位並加上外鍵約束
 CREATE TABLE "milestone" (
-    "id" serial PRIMARY KEY,
-    "project_id" int, -- 對應的專案 ID
-    "week" int , -- 第幾週
-    "name" varchar(255), -- 里程碑名稱
-    "description" text, -- 里程碑描述
-    "start_date" date, -- 開始日期
-    "end_date" date CHECK ("start_date" < "end_date"),
-    "is_completed" boolean DEFAULT false, -- 是否完成
-    "is_deleted" boolean DEFAULT false, -- 是否已刪除
-    "created_at" timestamp DEFAULT current_timestamp,
-    "updated_at" timestamp DEFAULT current_timestamp,
+    "id" SERIAL PRIMARY KEY,
+    "project_id" INT NOT NULL, -- 對應的專案 ID
+    "week" INT NOT NULL, -- 第幾週（必須為正數）
+    "name" VARCHAR(255) NOT NULL,
+    "description" TEXT,
+    "start_date" DATE NOT NULL,
+    "end_date" DATE NOT NULL CHECK ("start_date" < "end_date"),
+    "is_completed" BOOLEAN DEFAULT false,
+    "is_deleted" BOOLEAN DEFAULT false,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY ("project_id") REFERENCES "project"("id") ON DELETE CASCADE
 );
 
 CREATE INDEX idx_milestone_project_id ON "milestone"("project_id");
 
--- 創建 task 表
+-- 建立 ENUM 類型，限制天數存入特定星期值
 CREATE TYPE "day_enum" AS ENUM ('Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday');
 
+-- 任務表，規範必要欄位及外鍵參照
 CREATE TABLE "task" (
-    "id" serial PRIMARY KEY,
-    "milestone_id" int NOT NULL, -- 對應的里程碑 ID
-    "name" varchar(255), -- 任務名稱
-    "description" text, -- 任務描述
-    "days_of_week" day_enum[], -- 限定只能存 ENUM 類型值的陣列
-    "is_completed" boolean DEFAULT false, -- 是否完成
-    "is_deleted" boolean DEFAULT false, -- 是否已刪除
-    "created_at" timestamp DEFAULT current_timestamp,
-    "updated_at" timestamp DEFAULT current_timestamp,
+    "id" SERIAL PRIMARY KEY,
+    "milestone_id" INT NOT NULL, -- 對應的里程碑 ID
+    "name" VARCHAR(255) NOT NULL,
+    "description" TEXT,
+    "days_of_week" day_enum[] NOT NULL, -- 限定只能存 ENUM 類型值的陣列
+    "is_completed" BOOLEAN DEFAULT false,
+    "is_deleted" BOOLEAN DEFAULT false,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY ("milestone_id") REFERENCES "milestone"("id") ON DELETE CASCADE
 );
 
-CREATE INDEX idx_task_milestone_id ON "task"("milestone_id");
-
--- 通用文章表，包含學習成果、便利貼、覆盤。
-CREATE TABLE post (
+-- 通用文章表，包含學習成果、便利貼，統一以 project_id 表示所屬專案。
+CREATE TABLE "post" (
     "id" SERIAL PRIMARY KEY,
-    "study_plan_id" INT REFERENCES project(id) ON DELETE CASCADE,
-    "user_id"  INT REFERENCES users(id) ON DELETE CASCADE,
-    "type" VARCHAR(20) CHECK (type IN ('outcome', 'note', 'review')) NOT NULL,
+    "project_id" INT NOT NULL REFERENCES "project"("id") ON DELETE CASCADE,
+    "user_id" INT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "type" VARCHAR(20) NOT NULL CHECK ("type" IN ('outcome', 'note')),
+    "week" INT NOT NULL,
+    "title" VARCHAR(255) NOT NULL,
     "content" TEXT NOT NULL,
-    "date" date NOT NULL, 
-    "visibility" VARCHAR(10) CHECK (visibility IN ('public', 'private')) DEFAULT 'private',
-    "status" VARCHAR(20) CHECK (status IN ('draft', 'published')) DEFAULT 'draft',
+    "date" DATE NOT NULL, 
+    "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public', 'mentor_participant', 'private')),
+    "status" VARCHAR(20) DEFAULT 'draft' CHECK ("status" IN ('draft', 'published')),
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE INDEX idx_posts_study_plan_status ON post(study_plan_id, status);
 
--- 學習成果(outcome)表
-CREATE TABLE outcome (
-    id SERIAL PRIMARY KEY,
-    post_id INT,
-    image_urls TEXT[],  -- 儲存圖片 URL
-    video_urls TEXT[] ,  -- 儲存影片 URL
-    visibility VARCHAR(10) CHECK (visibility IN ('public', 'private')) DEFAULT 'private',
-    created_at timestamp DEFAULT current_timestamp,
-    updated_at timestamp DEFAULT current_timestamp,
+CREATE INDEX idx_posts_project_status ON "post"("project_id", "status");
+
+-- 學習成果表，針對 post 表類型為 outcome 的文章
+CREATE TABLE "outcome" (
+    "id" SERIAL PRIMARY KEY,
+    "post_id" INT NOT NULL,
+    "image_urls" TEXT[],  -- 儲存圖片 URL
+    "video_urls" TEXT[],  -- 儲存影片 URL
+    "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public', 'private')),
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY ("post_id") REFERENCES "post"("id") ON DELETE CASCADE
 );
-CREATE INDEX idx_outcome_post_id ON outcome(post_id);
 
+CREATE INDEX idx_outcome_post_id ON "outcome"("post_id");
 
--- 便利貼(note)表。目前便利貼是針對專案相關。
-CREATE TABLE note (
-    id SERIAL PRIMARY KEY,
-    post_id INT,
-    image_urls TEXT[],  -- 儲存圖片 URL
-    video_urls TEXT[],   -- 儲存影片 URL
-    visibility VARCHAR(10) CHECK (visibility IN ('public', 'private')) DEFAULT 'private',
-    created_at timestamp DEFAULT current_timestamp,
-    updated_at timestamp DEFAULT current_timestamp,
+-- 便利貼表，適用於專案相關的便利貼文章
+CREATE TABLE "note" (
+    "id" SERIAL PRIMARY KEY,
+    "post_id" INT NOT NULL,
+    "image_urls" TEXT[],  -- 儲存圖片 URL
+    "video_urls" TEXT[],  -- 儲存影片 URL
+    "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public', 'private')),
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY ("post_id") REFERENCES "post"("id") ON DELETE CASCADE
 );
-CREATE INDEX idx_note_post_id ON note(post_id);
 
--- 覆盤
-CREATE TABLE review (
-    id SERIAL PRIMARY KEY,
-    post_id INT,
-    mood VARCHAR(20) CHECK (mood IN ('happy', 'calm', 'anxious', 'tired', 'frustrated')) NOT NULL,
-    stress_level SMALLINT CHECK (stress_level BETWEEN 1 AND 10) NOT NULL,
-    learning_review SMALLINT CHECK (learning_review BETWEEN 1 AND 10) NOT NULL,
-    adjustment_plan text, -- 調整與規劃
-    visibility VARCHAR(10) CHECK (visibility IN ('public', 'private')) DEFAULT 'private',
-    created_at timestamp DEFAULT current_timestamp,
-    updated_at timestamp DEFAULT current_timestamp,
+CREATE INDEX idx_note_post_id ON "note"("post_id");
+
+-- 覆盤表，針對專案進行回顧與調整
+CREATE TABLE "review" (
+    "id" SERIAL PRIMARY KEY,
+    "post_id" INT NOT NULL, -- adjust_plan
+    "mood" VARCHAR(20) NOT NULL CHECK ("mood" IN ('happy', 'calm', 'anxious', 'tired', 'frustrated')),
+    "mood_description" TEXT,
+    "stress_level" SMALLINT NOT NULL CHECK ("stress_level" BETWEEN 1 AND 10),
+    "learning_review" SMALLINT NOT NULL CHECK ("learning_review" BETWEEN 1 AND 10),
+    "learning_feedback" TEXT,
+    "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public', 'private')),
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY ("post_id") REFERENCES "post"("id") ON DELETE CASCADE
 );
-CREATE INDEX idx_review_post_id ON review(post_id);
 
--- 儲存回覆資訊。
-CREATE TABLE comments (
-    id SERIAL PRIMARY KEY,
-    post_id INT REFERENCES post(id) ON DELETE CASCADE,
-    user_id INT REFERENCES users(id) ON DELETE CASCADE,
-    content TEXT NOT NULL,
-    visibility VARCHAR(10) CHECK (visibility IN ('public', 'private')) DEFAULT 'private',
-    created_at timestamp DEFAULT current_timestamp,
-    updated_at timestamp DEFAULT current_timestamp
+CREATE INDEX idx_review_project_id ON "review"("project_id");
+
+-- 回覆評論表，存放針對文章的使用者評論
+CREATE TABLE "comments" (
+    "id" SERIAL PRIMARY KEY,
+    "post_id" INT NOT NULL REFERENCES "post"("id") ON DELETE CASCADE,
+    "user_id" INT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "content" TEXT NOT NULL,
+    "visibility" VARCHAR(10) DEFAULT 'private' CHECK ("visibility" IN ('public','mentor_participant','private')),
+    "mentor_id" INTEGER,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE INDEX idx_comments_post_user ON comments(post_id, user_id);
+
+CREATE INDEX idx_comments_post_user ON "comments"("post_id", "user_id");
 


### PR DESCRIPTION
## Summary by Sourcery

This pull request introduces the concept of weekly milestones and implements tables to support posts, outcomes, notes, reviews, comments, and likes. It also enhances the database schema by adding constraints, standardizing identifiers, and creating indexes for improved performance.

New Features:
- Introduced a 'week' column to the 'milestone' table to track the week number of each milestone.
- Implemented a generic 'post' table to store learning outcomes, notes, and reviews, associating them with projects.
- Created separate tables for 'outcome', 'note', and 'review' to store specific data related to each post type.
- Added a 'comments' table to store user comments on posts.
- Added a 'likes' table to store user likes on posts.

Enhancements:
- Standardized the use of 'id' as the external identifier for users and projects in the 'user_project' table.
- Added NOT NULL constraints to required fields in the 'project', 'milestone', 'task', and 'post' tables to ensure data integrity.
- Replaced the 'study_plan_id' column in the 'post' table with 'project_id' to align with the project-centric approach.
- Added indexes to improve query performance on 'milestone', 'task', 'post', 'outcome', 'note', 'review', 'comments', and 'likes' tables.

Chores:
- Renamed tables to use lowercase names for consistency.